### PR TITLE
Add trophy for nom

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ mp4parse-rust | [#2](https://github.com/mozilla/mp4parse-rust/issues/2) | afl
 mp4parse-rust | [#4](https://github.com/mozilla/mp4parse-rust/issues/4) | afl
 mp4parse-rust | [#5](https://github.com/mozilla/mp4parse-rust/issues/5) | afl
 mp4parse-rust | [#6](https://github.com/mozilla/mp4parse-rust/issues/6) | afl
+nom | [arithmetic overflow](https://github.com/Geal/nom/pull/486) | libfuzzer
 npy-rs | [arithmetic overflow](https://github.com/potocpav/npy-rs/pull/2) | libfuzzer
 ntp | [panic caused by unwrap on invalid input](https://github.com/JeffBelgum/ntp/commit/f23ded23c26a5326dae249905d298e8c5f51d371) | libfuzzer
 num | [panic on `BigInt` parsing](https://github.com/rust-num/num/issues/268) | libfuzzer


### PR DESCRIPTION
Originally found in https://github.com/rusticata/x509-parser/issues/1 but it was an upstream `nom` issue -
 reported here https://github.com/Geal/nom/issues/481 and fixed in https://github.com/Geal/nom/pull/486.