### PR TITLE
Create bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+block-labels = [ "DO NOT MERGE YET" ]


### PR DESCRIPTION
This way, if people try to use bors again (muscle-memory from all the other rust-fuzz repos), it'll actually work.