### PR TITLE
Add Claxon trophies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ brotli-rs | [#9](https://github.com/ende76/brotli-rs/issues/9) | afl | `arith`
 bson | [multiple bugs, including arithmetic overflow](https://github.com/zonyitoo/bson-rs/issues/64) | libfuzzer | `arith`, `other`, `unwrap`
 capnproto-rust | [Multiple bugs, including a memory safety bug](https://dwrensha.github.io/capnproto-rust/2017/02/27/cargo-fuzz.html) | libfuzzer | | ❗️
 capnproto-rust | [reddit](https://www.reddit.com/r/rust/comments/89y5eo/fuzzing_as_a_service_startup_looking_for_rust/dwueuww/), [`e72746c`](https://github.com/capnproto/capnproto-rust/commit/e72746cdd4c672a4b8881ed2ed0375b69d1afb3a) | libfuzzer | `logic`
+claxon | [c036944](https://github.com/ruuda/claxon/commit/c036944b93ed8f96701d39b3a76392d30fc12d19) | libfuzzer | `logic`
+claxon | [875c3b2](https://github.com/ruuda/claxon/commit/875c3b2e76326a5672af9d9ac8f7f36def514834) | libfuzzer | `logic`
+claxon | [21b1db4](https://github.com/ruuda/claxon/commit/21b1db4a7891afdd453ee60085afc92cf61913ca) | libfuzzer | `oor`
+claxon | [0fd8815](https://github.com/ruuda/claxon/commit/0fd88158a4d29c27f8218a324505583906228289) | libfuzzer | `unwrap`
+claxon | [Massive slowdown on malformed input](https://github.com/ruuda/claxon/commit/0ec74f400cf71b376be59b16d7411d951d5eaecc) | libfuzzer | `other`
 comrak | [#65](https://github.com/kivikakk/comrak/pull/65) | libfuzzer | `oor`
 cpp_demangle | [#41](https://github.com/fitzgen/cpp_demangle/pull/41) | afl |
 cranelift | [#418](https://github.com/CraneStation/cranelift/issues/418) | libfuzzer | `logic`


### PR DESCRIPTION
Claxon has been fuzzed by the author, but the trophies were not added to the trophy case. This PR rectifies that.

I have omitted harmless overflows that triggered panics in debug mode only.