### PR TITLE
Add bug found in just

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jpeg-decoder | [#38](https://github.com/kaksmet/jpeg-decoder/issues/38) | afl | 
 jpeg-decoder | [#50](https://github.com/kaksmet/jpeg-decoder/issues/50) | afl | `oom`
 jpeg-decoder | [arithmetic overflow](https://github.com/kaksmet/jpeg-decoder/issues/69) | libfuzzer | `arith`
 json-rust | [arithmetic overflow](https://github.com/maciejhirsz/json-rust/issues/139) | afl | `arith`
+just | [#363](https://github.com/casey/just/issues/363) | libfuzzer | `logic`
 lewton | [index out of bounds](https://github.com/RustAudio/lewton/issues/27) | honggfuzz | `oor`
 lewton | [index out of bounds](https://github.com/RustAudio/lewton/issues/33) | afl | `oor`
 lewton | [memory exhaustion due to integer underflow](https://github.com/RustAudio/lewton/issues/32) | afl | `arith`, `oom`


### PR DESCRIPTION
@RadicalZephyr added fuzz testing using `cargo-fuzz` to `just`, which found [a bug in the parser](github.com/casey/just/issues/363). It wasn't even a particularly weird edge case, and was definitely something that a normal user could have encountered.

Thanks `cargo-fuzz`!