### PR TITLE
Add bug found in lexical.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ jpeg-decoder | [#50](https://github.com/kaksmet/jpeg-decoder/issues/50) | afl | 
 jpeg-decoder | [arithmetic overflow](https://github.com/kaksmet/jpeg-decoder/issues/69) | libfuzzer | `arith`
 json-rust | [arithmetic overflow](https://github.com/maciejhirsz/json-rust/issues/139) | afl | `arith`
 just | [#363](https://github.com/casey/just/issues/363) | libfuzzer | `logic`
+lexical | [arithmetic overflow](https://github.com/Alexhuszagh/rust-lexical/commit/cc8778384e6d77031b45aef2cb9cb831670573d6) | libfuzzer | `arith`
+lexical | [arithmetic overflow](https://github.com/Alexhuszagh/rust-lexical/commit/466a63395e8d890cfa1fb650abb6e78fafe11771) | libfuzzer | `arith`
+lexical | [Out-of-bounds read in unsafe code](https://github.com/Alexhuszagh/rust-lexical/commit/cc8778384e6d77031b45aef2cb9cb831670573d6) | libfuzzer | `oor`
 lewton | [index out of bounds](https://github.com/RustAudio/lewton/issues/27) | honggfuzz | `oor`
 lewton | [index out of bounds](https://github.com/RustAudio/lewton/issues/33) | afl | `oor`
 lewton | [memory exhaustion due to integer underflow](https://github.com/RustAudio/lewton/issues/32) | afl | `arith`, `oom`


### PR DESCRIPTION
Not sure if I should write the commit which found both arithmetic overflow and an out-of-bounds-read in unsafe code on the same line, like the "multiple bugs found in ...".