### PR TITLE
Panic found in `der`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cssparser | [floating-point parsing imprecision](https://github.com/servo/rust-c
 cursive | [grapheme boundary correctness](https://github.com/gyscos/cursive/issues/489) | libfuzzer | `utf-8`
 deflate-rs | [#40](https://github.com/image-rs/deflate-rs/issues/40) | afl | `logic`
 deflate-rs | [#42](https://github.com/image-rs/deflate-rs/issues/42) | afl | `logic`
+der | [arithmetic overflow leading to index out of bounds](https://github.com/RustCrypto/formats/pull/447) | libfuzzer | `arith`
 der-parser | [arithmetic overflow](https://github.com/rusticata/der-parser/issues/2) | libfuzzer | `arith`
 dhcp4r | [#6](https://github.com/krolaw/dhcp4r/issues/6) | libfuzzer | `oor`
 encoding_rs | [#44](https://github.com/hsivonen/encoding_rs/issues/44) | afl | `logic`


### PR DESCRIPTION
Fixed in https://github.com/RustCrypto/formats/pull/447 .